### PR TITLE
Add option to allow the scanning of AI plates

### DIFF
--- a/wraithv2/CHANGEMEconfig_wraithv2.lua
+++ b/wraithv2/CHANGEMEconfig_wraithv2.lua
@@ -22,8 +22,6 @@ local config = {
     ,expiresUid = "expiration"
     -- statuses to flag on when scanned
     ,flagOnStatuses = {"STOLEN", "EXPIRED", "PENDING", "SUSPENDED"}
-    -- Scan AI plates
-    ,scanAi = false
 }
 
 if config.enabled then

--- a/wraithv2/CHANGEMEconfig_wraithv2.lua
+++ b/wraithv2/CHANGEMEconfig_wraithv2.lua
@@ -12,16 +12,18 @@ local config = {
     configVersion = "1.5"
 
     -- use vehicle registration expirations, or not
-    ,useExpires = true 
+    ,useExpires = true
      -- use middle initials?
     ,useMiddleInitial = true
     -- alert if no registration was found on scan?
-    ,alertNoRegistration = true 
+    ,alertNoRegistration = true
     -- if your custom vehicle record is different, change the below
     ,statusUid = "status"
     ,expiresUid = "expiration"
     -- statuses to flag on when scanned
     ,flagOnStatuses = {"STOLEN", "EXPIRED", "PENDING", "SUSPENDED"}
+    -- Scan AI plates
+    ,scanAi = false
 }
 
 if config.enabled then

--- a/wraithv2/sv_wraithv2.lua
+++ b/wraithv2/sv_wraithv2.lua
@@ -38,7 +38,10 @@ if pluginConfig.enabled then
             end
             if #vehData < 1 then
                 debugLog("No data returned")
-                return
+                if pluginConfig.scanAi then
+                else
+                    return
+                end
             end
             local reg = false
             for _, veh in pairs(vehData) do
@@ -49,7 +52,10 @@ if pluginConfig.enabled then
             end
             if #charData < 1 then
                 debugLog("Invalid registration")
-                return
+                if pluginConfig.scanAi then
+                else
+                    return
+                end
             end
             local person = charData[1]
             if reg then
@@ -57,15 +63,24 @@ if pluginConfig.enabled then
                 local plate = reg.plate
                 if regData == nil then
                     debugLog("regData is nil, skipping plate lock.")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1] == nil then
                     debugLog("regData is empty, skipping")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1].status == nil then
                     warnLog(("Plate %s was scanned by %s, but status was nil. Record: %s"):format(plate, source, json.encode(regData[1])))
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 local plate = reg.plate
                 local statusUid = pluginConfig.statusUid ~= nil and pluginConfig.statusUid or "status"
@@ -136,15 +151,24 @@ if pluginConfig.enabled then
                 local plate = reg.plate
                 if regData == nil then
                     debugLog("regData is nil, skipping plate lock.")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1] == nil then
                     debugLog("regData is empty, skipping")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1].status == nil then
                     warnLog(("Plate %s was scanned by %s, but status was nil. Record: %s"):format(plate, source, json.encode(regData[1])))
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 local statusUid = pluginConfig.statusUid ~= nil and pluginConfig.statusUid or "status"
                 local expiresUid = pluginConfig.expiresUid ~= nil and pluginConfig.expiresUid or "expiration"


### PR DESCRIPTION
In the config there will now be an option called `scanAi`. This is by default set to `false`, meaning the script will simply not run AI Plates. If `scanAi = true` then the script will "scan" the AI plate and will return the "No registration" alert prompt