### PR TITLE
Added more developer functionality

### DIFF
--- a/wraithv2/CHANGEMEconfig_wraithv2.lua
+++ b/wraithv2/CHANGEMEconfig_wraithv2.lua
@@ -22,8 +22,6 @@ local config = {
     ,expiresUid = "expiration"
     -- statuses to flag on when scanned
     ,flagOnStatuses = {"STOLEN", "EXPIRED", "PENDING", "SUSPENDED"}
-    -- Scan AI plates
-    ,scanAi = false
 }
 
 if config.enabled then

--- a/wraithv2/CHANGEMEconfig_wraithv2.lua
+++ b/wraithv2/CHANGEMEconfig_wraithv2.lua
@@ -12,16 +12,18 @@ local config = {
     configVersion = "1.5"
 
     -- use vehicle registration expirations, or not
-    ,useExpires = true 
+    ,useExpires = true
      -- use middle initials?
     ,useMiddleInitial = true
     -- alert if no registration was found on scan?
-    ,alertNoRegistration = true 
+    ,alertNoRegistration = true
     -- if your custom vehicle record is different, change the below
     ,statusUid = "status"
     ,expiresUid = "expiration"
     -- statuses to flag on when scanned
     ,flagOnStatuses = {"STOLEN", "EXPIRED", "PENDING", "SUSPENDED"}
+    -- Scan AI plates
+    ,scanAi = false
 }
 
 if config.enabled then

--- a/wraithv2/sv_wraithv2.lua
+++ b/wraithv2/sv_wraithv2.lua
@@ -38,7 +38,10 @@ if pluginConfig.enabled then
             end
             if #vehData < 1 then
                 debugLog("No data returned")
-                return
+                if pluginConfig.scanAi then
+                else
+                    return
+                end
             end
             local reg = false
             for _, veh in pairs(vehData) do
@@ -49,7 +52,10 @@ if pluginConfig.enabled then
             end
             if #charData < 1 then
                 debugLog("Invalid registration")
-                return
+                if pluginConfig.scanAi then
+                else
+                    return
+                end
             end
             local person = charData[1]
             if reg then
@@ -57,15 +63,24 @@ if pluginConfig.enabled then
                 local plate = reg.plate
                 if regData == nil then
                     debugLog("regData is nil, skipping plate lock.")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1] == nil then
                     debugLog("regData is empty, skipping")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1].status == nil then
                     warnLog(("Plate %s was scanned by %s, but status was nil. Record: %s"):format(plate, source, json.encode(regData[1])))
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 local plate = reg.plate
                 local statusUid = pluginConfig.statusUid ~= nil and pluginConfig.statusUid or "status"
@@ -136,15 +151,24 @@ if pluginConfig.enabled then
                 local plate = reg.plate
                 if regData == nil then
                     debugLog("regData is nil, skipping plate lock.")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1] == nil then
                     debugLog("regData is empty, skipping")
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 if regData[1].status == nil then
                     warnLog(("Plate %s was scanned by %s, but status was nil. Record: %s"):format(plate, source, json.encode(regData[1])))
-                    return
+                    if pluginConfig.scanAi then
+                    else
+                        return
+                    end
                 end
                 local statusUid = pluginConfig.statusUid ~= nil and pluginConfig.statusUid or "status"
                 local expiresUid = pluginConfig.expiresUid ~= nil and pluginConfig.expiresUid or "expiration"


### PR DESCRIPTION
This update was created with the idea of developers in mind. The following additions have been made to allow developers to work easier. 

# Event Changes
## wk:onPlateLocked
- Added 2 extra parameters to the function `cbType` & `returnEvent`
#### What does this mean? 
You can now force the plugin to CB back to you simply by passing a return event name to the `returnEvent` parameter. You can also choose whether you would like to call back to server scope, or client scope using the `cbType` parameter.

#### Example Usage
```lua
TriggerServerEvent('wk:onPlateLocked', cam, plate, 1, 'client', 'Sonoran::mcc::lockReturn')
```
This will cause the plugin to trigger the event `Sonoran::mcc::lockReturn` to the `client` scope with the following data:
| Data Name | Contents |
|----------------|---------------|
|  `regData` | Data in regards to the registration of the vehicle |
| `vehData` | Data in regards to the vehicle associated with the plate | 
| `charData` | Data in regards to the character the plate is registered to | 
| `boloData` | Data in regards to any Bolos associated with the vehicle | 
| `plate` | The plate numbers
| `cam` | What camera captured the plate
| `index` | The index 

#### Example Handling 
```lua
 RegisterNetEvent('Sonoran::mcc::lockReturn', function(data)
    if #data.vehData < 1 then
         print('vehicle was not found in CAD')
    end
 end)
```

This update was created with the idea of developers in mind. The following additions have been made to allow developers to work easier. 

## wk:onPlateScanned
- Added 2 extra parameters to the function `cbType` & `returnEvent`
#### What does this mean? 
You can now force the plugin to CB back to you simply by passing a return event name to the `returnEvent` parameter. You can also choose whether you would like to call back to server scope, or client scope using the `cbType` parameter.

#### Example Usage
```lua
TriggerServerEvent('wk:onPlateScanned', cam, plate, 1, 'client', 'Sonoran::mcc::scanReturn')
```
This will cause the plugin to trigger the event `Sonoran::mcc::scanReturn` to the `client` scope with the following data:
| Data Name | Contents |
|----------------|---------------|
|  `regData` | Data in regards to the registration of the vehicle |
| `vehData` | Data in regards to the vehicle associated with the plate | 
| `charData` | Data in regards to the character the plate is registered to | 
| `boloData` | Data in regards to any Bolos associated with the vehicle | 
| `plate` | The plate numbers
| `cam` | What camera captured the plate
| `index` | The index 

#### Example Handling 
```lua
 RegisterNetEvent('Sonoran::mcc::scanReturn', function(data)
    if #data.vehData < 1 then
         print('vehicle was not found in CAD')
    end
 end)
```

# Notes
Valid `cbType` parameters: 
| Parameter Name | Result | 
| -- | --- |
| `'client'` | Will cause the plugin to trigger a client event to the passed `returnEvent` to the source
| `'server'` | Will cause the plugin to trigger a server event to the passed `returnEvent`

**If you do not want to use the CB functionality, simply do not pass a `cbType` or `returnEvent` parameter**